### PR TITLE
Add purchase orders to api and UI

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -3,10 +3,12 @@ import {Module} from '@nestjs/common';
 import {AppController} from './app.controller';
 import {AppService} from './app.service';
 import {ParentItemsModule} from "../parent-items/parent-items.module";
+import { PurchaseOrdersModule } from '../purchase-orders/purchase-orders.module';
 
 @Module({
   imports: [
     ParentItemsModule,
+    PurchaseOrdersModule
   ],
   controllers: [AppController],
   providers: [AppService,],

--- a/apps/api/src/purchase-orders/purchase-orders.controller.ts
+++ b/apps/api/src/purchase-orders/purchase-orders.controller.ts
@@ -1,0 +1,18 @@
+import {Controller, Get, Param} from '@nestjs/common';
+import { PurchaseOrdersService } from './purchase-orders.service';
+
+@Controller('purchase-orders')
+export class PurchaseOrdersController {
+  constructor(private readonly purchaseOrdersService: PurchaseOrdersService) {
+  }
+
+  @Get()
+  findAll() {
+    return this.purchaseOrdersService.findAll();
+  }
+
+  @Get(':sortBy')
+  findAllSorted(@Param('sortBy') sortedBy: string) {
+    return this.purchaseOrdersService.findAllSorted(sortedBy);
+  }
+}

--- a/apps/api/src/purchase-orders/purchase-orders.controller.ts
+++ b/apps/api/src/purchase-orders/purchase-orders.controller.ts
@@ -8,7 +8,7 @@ export class PurchaseOrdersController {
 
   @Get()
   findAll() {
-    return this.purchaseOrdersService.findAll();
+    return this.purchaseOrdersService.findAllSorted();
   }
 
   @Get(':sortBy')

--- a/apps/api/src/purchase-orders/purchase-orders.module.ts
+++ b/apps/api/src/purchase-orders/purchase-orders.module.ts
@@ -1,0 +1,11 @@
+import {Module} from '@nestjs/common';
+import {PrismaService} from "../prisma.service";
+import { PurchaseOrdersController } from './purchase-orders.controller';
+import { PurchaseOrdersService } from './purchase-orders.service';
+
+@Module({
+  imports: [],
+  controllers: [PurchaseOrdersController],
+  providers: [PurchaseOrdersService, PrismaService],
+})
+export class PurchaseOrdersModule {}

--- a/apps/api/src/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/purchase-orders/purchase-orders.service.ts
@@ -1,0 +1,17 @@
+import {Injectable} from '@nestjs/common';
+import {PurchaseOrders} from "@prisma/client";
+import {PrismaService} from "../prisma.service";
+
+@Injectable()
+export class PurchaseOrdersService {
+  constructor(private prisma: PrismaService) {
+  }
+
+  async findAll(): Promise<PurchaseOrders[]> {
+    return (await this.prisma.purchaseOrders.findMany({include: {purchase_order_line_items: true}})).sort((a, b) => new Date(a.expected_delivery_date).getTime() - new Date(b.expected_delivery_date).getTime());
+  }
+
+  async findAllSorted(sortBy: string): Promise<PurchaseOrders[]> {
+    return (await this.prisma.purchaseOrders.findMany({include: {purchase_order_line_items: true}})).sort((a, b) => 0 - (b[sortBy] > a[sortBy] ? 1 : -1));
+  }
+}

--- a/apps/api/src/purchase-orders/purchase-orders.service.ts
+++ b/apps/api/src/purchase-orders/purchase-orders.service.ts
@@ -7,11 +7,16 @@ export class PurchaseOrdersService {
   constructor(private prisma: PrismaService) {
   }
 
-  async findAll(): Promise<PurchaseOrders[]> {
-    return (await this.prisma.purchaseOrders.findMany({include: {purchase_order_line_items: true}})).sort((a, b) => new Date(a.expected_delivery_date).getTime() - new Date(b.expected_delivery_date).getTime());
-  }
-
-  async findAllSorted(sortBy: string): Promise<PurchaseOrders[]> {
-    return (await this.prisma.purchaseOrders.findMany({include: {purchase_order_line_items: true}})).sort((a, b) => 0 - (b[sortBy] > a[sortBy] ? 1 : -1));
+  async findAllSorted(sortBy = "expected_delivery_date"): Promise<PurchaseOrders[]> {
+    return (await this.prisma.purchaseOrders.findMany({orderBy: [
+      {
+        [sortBy]: 'asc',
+      },
+      {
+        vendor_name: 'asc',
+      },
+    ],
+    include: {purchase_order_line_items: true}
+    }));
   }
 }

--- a/apps/client/app/components/selectList.tsx
+++ b/apps/client/app/components/selectList.tsx
@@ -1,0 +1,25 @@
+"use client"
+import React from 'react'
+
+interface SelectProps {
+    list: KeyValuePair[];
+    selected: string;
+}
+
+export default function SelectList({list, selected = ''}: SelectProps) {
+    const handleSort = (value: string) => {
+        console.log(value)
+        window.location.href = `http://localhost:4200/purchase-orders?sort=${value}`
+    }
+
+
+    
+  return (
+    //@ts-ignore
+    <select defaultValue={selected} onChange={(e) => handleSort(e.nativeEvent.target?.value)}>
+        {list.map(item => (
+            <option key={item.key} value={item.key}>{item.value}</option>
+        ))}
+    </select>
+  )
+}

--- a/apps/client/app/interfaces.ts
+++ b/apps/client/app/interfaces.ts
@@ -1,0 +1,32 @@
+interface PurchaseOrderLineItem {
+    id: number;
+    item_id: number;
+    unit_cost: number;
+    quantity: number;
+  
+  }
+  
+  interface PurchaseOrder {
+    id: number;
+    vendor_name: string;
+    order_date: string;
+    expected_delivery_date: string;
+    purchase_order_line_items: PurchaseOrderLineItem[];
+  }
+  
+  interface Item {
+    id: number;
+    name: string;
+    sku: string;
+  }
+  
+  interface ParentItem {
+    id: number;
+    name: string;
+    items: Item[];
+  }
+
+  interface KeyValuePair {
+    key: string;
+    value: string;
+  }

--- a/apps/client/app/parent-items/page.tsx
+++ b/apps/client/app/parent-items/page.tsx
@@ -1,26 +1,8 @@
-interface Item {
-  id: number;
-  name: string;
-  sku: string;
-}
+import { getParentItems } from "../utils";
 
-interface ParentItem {
-  id: number;
-  name: string;
-  items: Item[];
-}
-
-async function getData(): Promise<ParentItem[]> {
-  const res = await fetch('http://localhost:3100/api/parent-items', {cache: 'no-cache'});
-  if (!res.ok) {
-    throw new Error('Failed to fetch data');
-  }
-
-  return res.json();
-}
 
 export default async function Index() {
-  const data = await getData()
+  const data = await getParentItems()
 
   return (
     <>

--- a/apps/client/app/purchase-orders/page.tsx
+++ b/apps/client/app/purchase-orders/page.tsx
@@ -1,8 +1,92 @@
+import SelectList from "../components/selectList";
+import { getFormattedDate, getParentItems, getPurchaseOrders } from "../utils";
 
-export default async function Index() {
+const sortByArr = [
+  {
+      key: "expected_delivery_date",
+      value: "Delivery Date",
+  },
+  {
+      key: "vendor_name",
+      value: "Vendor Name",
+  },
+  {
+      key: "order_date",
+      value: "Order Date",
+  },
+];
+
+export default async function Index({ searchParams }: any) {
+  const { sort } = searchParams;
+  let purchaseOrders = await getPurchaseOrders(sort);
+  const parentItems = await getParentItems();
+  
+
+  
+  let items: Item[] = [];
+
+  // Hacky, but but needed a quick way to get all items from the db.
+  parentItems.forEach(parentItem => (
+    items.push(...parentItem.items)
+  ))
+
+
+
   return (
     <>
       <h1 className="text-2xl">Purchase Orders</h1>
+      <div className="">
+        <SelectList list={sortByArr} selected={sort} />
+      </div>
+      <table className="border-collapse table-auto w-full text-sm">
+        <thead>
+        <tr>
+          <th
+            className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400 text-left">#
+          </th>
+          <th
+            className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400 text-left">Delivery Date
+          </th>
+          <th
+            className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400 text-left">Order Date
+          </th>
+          <th
+            className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400 text-left">Purchase Order
+          </th>
+          <th
+            className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400 text-left">Line Items
+          </th>
+        </tr>
+        </thead>
+        <tbody className="bg-white dark:bg-slate-800">
+        {purchaseOrders.map((purchaseOrder: PurchaseOrder) => {
+          let total = 0;
+          return (
+          <tr key={purchaseOrder.id}>
+            <td
+              className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">{purchaseOrder.id}</td>
+            <td
+              className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">{getFormattedDate(new Date(purchaseOrder.expected_delivery_date))}</td>
+            <td
+              className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">{getFormattedDate(new Date(purchaseOrder.order_date))}</td>
+            <td
+              className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">{purchaseOrder.vendor_name}</td>
+            <td className="border-b border-slate-100 dark:border-slate-700 p-4 pl-8 text-slate-500 dark:text-slate-400">
+              <ul>
+                {purchaseOrder.purchase_order_line_items.map((lineItem) => {
+                  const {id, unit_cost, quantity} = lineItem;
+                  total += unit_cost * quantity;
+                  const item = items.find(i => i.id === lineItem.item_id);
+                  return(
+                  <li key={id}>${unit_cost} {quantity} {item?.name}</li>
+                )})}
+                <li>Total: ${total}</li>
+              </ul>
+            </td>
+          </tr>
+        )})}
+        </tbody>
+      </table>
     </>
   );
 }

--- a/apps/client/app/utils.ts
+++ b/apps/client/app/utils.ts
@@ -1,0 +1,21 @@
+export const getFormattedDate = (date: Date) => {
+    return `${date.getDate()}/${date.getMonth()+1}/${date.getFullYear()}`;
+}
+  
+export async function getPurchaseOrders(sort = ""): Promise<PurchaseOrder[]> {
+    const res = await fetch(`http://localhost:3100/api/purchase-orders/${sort}`, {cache: 'no-cache'});
+    if (!res.ok) {
+      throw new Error('Failed to fetch data');
+    }
+  
+    return res.json();
+}
+  
+export async function getParentItems(): Promise<ParentItem[]> {
+    const res = await fetch('http://localhost:3100/api/parent-items', {cache: 'no-cache'});
+    if (!res.ok) {
+      throw new Error('Failed to fetch data');
+    }
+  
+    return res.json();
+}


### PR DESCRIPTION
- Add api call for retrieving all purchase orders /purchase-orders
- Add api call for retrieving all purchase orders sorted by a purchase order field /purchase-orders/<sortBy>
- Add UI for viewing all purchase orders under the "Purchase Orders" tab
- Display all purchase orders and each of their line items and Item names on the table along with a total. (See picture below).
- Add sort-ability for sorting the purchase orders by a purchase order field.

<img width="1125" alt="Screenshot 2024-01-31 at 9 11 40 AM" src="https://github.com/jenki5/goodDay-interview/assets/43391559/1a76f83d-8c08-46e9-8616-5ce8f56bfdec">
